### PR TITLE
Change color of package name to more bright

### DIFF
--- a/src/scripts/viewer/2d/graphUI.js
+++ b/src/scripts/viewer/2d/graphUI.js
@@ -2,7 +2,7 @@ var svg = require('simplesvg');
 var eventify = require('ngraph.events');
 var arrow = require('./arrow');
 var defaultNodeColor = '#CFCCDF';
-var defaultTextColor = '#484A5C';
+var defaultTextColor = '#70738f';
 
 module.exports = function(svgRoot) {
   var nodeUIModels = Object.create(null);


### PR DESCRIPTION
I found default text of packages little darker to read from screen. So I just increased brightness value of this color
<img width="480" alt="image" src="https://user-images.githubusercontent.com/1851469/56438429-9b121180-62eb-11e9-8cca-24cb8c1d09b4.png">
<img width="456" alt="image" src="https://user-images.githubusercontent.com/1851469/56438460-b4b35900-62eb-11e9-9ebd-124c673c230d.png">

