### PR TITLE
replace deprecated `registry.npmjs.cf` with `registry.npmjs.org`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Responsive view:
 
 The website is entirely hosted on [GitHub Pages](https://pages.github.com/).
 
-The npm data is coming from `registry.npmjs.cf` and is collected by [npmgraphbuilder](https://github.com/anvaka/npmgraphbuilder) at real time.
+The npm data is coming from `registry.npmjs.org` and is collected by [npmgraphbuilder](https://github.com/anvaka/npmgraphbuilder) at real time.
 
 For CSS styles I'm using [twitter bootstrap](https://getbootstrap.com/css/) and [less](https://lesscss.org/).
 

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  registryUrl: 'https://registry.npmjs.cf/',
+  registryUrl: 'https://registry.npmjs.org/',
   autoCompleteUrl: 'https://registry.npmjs.org/-/v1/search?size=10&from=0'
 }


### PR DESCRIPTION
The PR closes #62.

`npmjs.cf` is being deprecated: https://github.com/npmjs-cf/meta/issues/8

Since now `registry.npmjs.org` now also has CORS support (https://github.com/npm/feedback/discussions/117#discussioncomment-2691120), the PR replaces `registry.npmjs.cf` with `registry.npmjs.org`.